### PR TITLE
Add EF Core SQLite Persistence Layer

### DIFF
--- a/backend/Ledger.Api/Ledger.Api.csproj
+++ b/backend/Ledger.Api/Ledger.Api.csproj
@@ -8,6 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/Ledger.Api/appsettings.json
+++ b/backend/Ledger.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Default": "Data Source=ledger.db"
+  }
 }

--- a/backend/Ledger.Application/Abstractions/IAccountRepository.cs
+++ b/backend/Ledger.Application/Abstractions/IAccountRepository.cs
@@ -1,0 +1,11 @@
+using Ledger.Domain.Accounts;
+
+namespace Ledger.Application.Abstractions;
+
+public interface IAccountRepository
+{
+    Task AddAsync(Account account, CancellationToken ct);
+    Task<Account?> GetByIdAsync(AccountId id, CancellationToken ct);
+    Task<List<Account>> GetAllAsync(CancellationToken ct);
+    Task SaveChangesAsync(CancellationToken ct);
+}

--- a/backend/Ledger.Application/Abstractions/ILedgerEntryRepository.cs
+++ b/backend/Ledger.Application/Abstractions/ILedgerEntryRepository.cs
@@ -1,0 +1,10 @@
+using Ledger.Domain.Accounts;
+using Ledger.Domain.Ledger;
+
+namespace Ledger.Application.Abstractions;
+
+public interface ILedgerEntryRepository
+{
+    Task AddAsync(LedgerEntry entry, CancellationToken ct);
+    Task<List<LedgerEntry>> GetByAccountIdAsync(AccountId accountId, CancellationToken ct);
+}

--- a/backend/Ledger.Application/Abstractions/ILedgerEntryRepository.cs
+++ b/backend/Ledger.Application/Abstractions/ILedgerEntryRepository.cs
@@ -7,4 +7,5 @@ public interface ILedgerEntryRepository
 {
     Task AddAsync(LedgerEntry entry, CancellationToken ct);
     Task<List<LedgerEntry>> GetByAccountIdAsync(AccountId accountId, CancellationToken ct);
+    Task SaveChangesAsync(CancellationToken ct);
 }

--- a/backend/Ledger.Infrastructure/DependencyInjection.cs
+++ b/backend/Ledger.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,24 @@
+using Ledger.Application.Abstractions;
+using Ledger.Infrastructure.Persistence;
+using Ledger.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ledger.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var conn = configuration.GetConnectionString("Default")
+                   ?? "Data Source=ledger.db";
+
+        services.AddDbContext<AppDbContext>(opt => opt.UseSqlite(conn));
+
+        services.AddScoped<IAccountRepository, AccountRepository>();
+        services.AddScoped<ILedgerEntryRepository, LedgerEntryRepository>();
+
+        return services;
+    }
+}

--- a/backend/Ledger.Infrastructure/Ledger.Infrastructure.csproj
+++ b/backend/Ledger.Infrastructure/Ledger.Infrastructure.csproj
@@ -5,6 +5,14 @@
     <ProjectReference Include="..\Ledger.Domain\Ledger.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/backend/Ledger.Infrastructure/Persistence/AppDbContext.cs
+++ b/backend/Ledger.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,18 @@
+using Ledger.Domain.Accounts;
+using Ledger.Domain.Ledger;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ledger.Infrastructure.Persistence;
+
+public sealed class AppDbContext : DbContext
+{
+    public DbSet<Account> Accounts => Set<Account>();
+    public DbSet<LedgerEntry> LedgerEntries => Set<LedgerEntry>();
+
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+}

--- a/backend/Ledger.Infrastructure/Persistence/Configurations/AccountConfiguration.cs
+++ b/backend/Ledger.Infrastructure/Persistence/Configurations/AccountConfiguration.cs
@@ -1,0 +1,46 @@
+using Ledger.Domain.Accounts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ledger.Infrastructure.Persistence.Configurations;
+
+public sealed class AccountConfiguration : IEntityTypeConfiguration<Account>
+{
+    public void Configure(EntityTypeBuilder<Account> builder)
+    {
+        builder.ToTable("Accounts");
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Id)
+            .HasConversion(
+                id => id.Value,
+                value => new AccountId(value)
+            )
+            .ValueGeneratedNever();
+
+        builder.Property(a => a.CustomerName)
+            .HasMaxLength(120)
+            .IsRequired();
+
+        builder.Property(a => a.Phone)
+            .HasMaxLength(40);
+
+        builder.Property(a => a.AccountNumber)
+            .HasMaxLength(40);
+
+        builder.Property(a => a.CreatedAtUtc)
+            .IsRequired();
+
+        // 1 Account -> many LedgerEntries
+        builder.HasMany(a => a.Entries)
+            .WithOne()
+            .HasForeignKey(e => e.AccountId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Map private backing field for encapsulation
+        builder.Navigation(a => a.Entries)
+            .HasField("_entries")
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+    }
+}

--- a/backend/Ledger.Infrastructure/Persistence/Configurations/LedgerEntryConfiguration.cs
+++ b/backend/Ledger.Infrastructure/Persistence/Configurations/LedgerEntryConfiguration.cs
@@ -1,0 +1,46 @@
+using Ledger.Domain.Accounts;
+using Ledger.Domain.Ledger;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Ledger.Infrastructure.Persistence.Configurations;
+
+public sealed class LedgerEntryConfiguration : IEntityTypeConfiguration<LedgerEntry>
+{
+    public void Configure(EntityTypeBuilder<LedgerEntry> builder)
+    {
+        builder.ToTable("LedgerEntries");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(e => e.AccountId)
+            .HasConversion(
+                id => id.Value,
+                value => new AccountId(value)
+            )
+            .IsRequired();
+
+        builder.Property(e => e.Type)
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(e => e.Amount)
+            .HasConversion(
+                money => money.Value,
+                value => new Money(value) // Money already validated at creation
+            )
+            .HasColumnType("decimal(18,2)")
+            .IsRequired();
+
+        builder.Property(e => e.Description)
+            .HasMaxLength(500);
+
+        builder.Property(e => e.CreatedAtUtc)
+            .IsRequired();
+
+        builder.HasIndex(e => new { e.AccountId, e.CreatedAtUtc });
+    }
+}

--- a/backend/Ledger.Infrastructure/Repositories/AccountRepository.cs
+++ b/backend/Ledger.Infrastructure/Repositories/AccountRepository.cs
@@ -1,0 +1,33 @@
+using Ledger.Application.Abstractions;
+using Ledger.Domain.Accounts;
+using Ledger.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ledger.Infrastructure.Repositories;
+
+public sealed class AccountRepository : IAccountRepository
+{
+    private readonly AppDbContext _db;
+
+    public AccountRepository(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task AddAsync(Account account, CancellationToken ct)
+        => await _db.Accounts.AddAsync(account, ct);
+
+    public async Task<Account?> GetByIdAsync(AccountId id, CancellationToken ct)
+        => await _db.Accounts
+            .Include(a => a.Entries)
+            .FirstOrDefaultAsync(a => a.Id == id, ct);
+
+    public async Task<List<Account>> GetAllAsync(CancellationToken ct)
+        => await _db.Accounts
+            .AsNoTracking()
+            .OrderByDescending(a => a.CreatedAtUtc)
+            .ToListAsync(ct);
+
+    public Task SaveChangesAsync(CancellationToken ct)
+        => _db.SaveChangesAsync(ct);
+}

--- a/backend/Ledger.Infrastructure/Repositories/LedgerEntryRepository.cs
+++ b/backend/Ledger.Infrastructure/Repositories/LedgerEntryRepository.cs
@@ -24,4 +24,7 @@ public sealed class LedgerEntryRepository : ILedgerEntryRepository
             .Where(e => e.AccountId == accountId)
             .OrderByDescending(e => e.CreatedAtUtc)
             .ToListAsync(ct);
+
+    public Task SaveChangesAsync(CancellationToken ct)
+     => _db.SaveChangesAsync(ct);
 }

--- a/backend/Ledger.Infrastructure/Repositories/LedgerEntryRepository.cs
+++ b/backend/Ledger.Infrastructure/Repositories/LedgerEntryRepository.cs
@@ -1,0 +1,27 @@
+using Ledger.Application.Abstractions;
+using Ledger.Domain.Accounts;
+using Ledger.Domain.Ledger;
+using Ledger.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ledger.Infrastructure.Repositories;
+
+public sealed class LedgerEntryRepository : ILedgerEntryRepository
+{
+    private readonly AppDbContext _db;
+
+    public LedgerEntryRepository(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task AddAsync(LedgerEntry entry, CancellationToken ct)
+        => await _db.LedgerEntries.AddAsync(entry, ct);
+
+    public async Task<List<LedgerEntry>> GetByAccountIdAsync(AccountId accountId, CancellationToken ct)
+        => await _db.LedgerEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == accountId)
+            .OrderByDescending(e => e.CreatedAtUtc)
+            .ToListAsync(ct);
+}


### PR DESCRIPTION
## Summary

This PR introduces the Infrastructure layer implementation using EF Core with SQLite for persistence.

## What Was Implemented

- `AppDbContext` configured with EF Core SQLite provider
- Entity configurations for:
  - `Account` (value object conversion + backing field mapping)
  - `LedgerEntry` (enum conversion + Money value object mapping)
- Repository abstractions defined in Application layer:
  - IAccountRepository
  - ILedgerEntryRepository
- EF-based repository implementations:
  - AccountRepository
  - LedgerEntryRepository
- Dependency injection wiring via `AddInfrastructure`
- SQLite connection string configuration in `appsettings.json`

## Persistence Design Decisions

- `AccountId` value object is mapped using EF Core value conversion
- `Money` value object is persisted as `decimal(18,2)`
- Private backing field `_entries` is mapped to preserve encapsulation
- Navigation configuration ensures 1-to-many relationship:
  - Account → LedgerEntries
- Foreign key constraint enforces referential integrity

## Architectural Notes

- Infrastructure depends on Application and Domain layers
- Domain remains persistence-agnostic (no EF attributes used)
- Repository pattern enforces dependency inversion principle
- DbContext is registered via DI to support testability and modularity
- SQLite chosen for lightweight embedded storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local persistent storage so accounts and ledger entries are saved and retrievable across sessions (defaults to ledger.db).
  * Enables durable creation, retrieval and listing of accounts and their ledger entries with consistent ordering and querying behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->