### PR TITLE
Enforce No-Overdraft Rule for Debit Transactions

### DIFF
--- a/backend/Ledger.Domain/Accounts/Account.cs
+++ b/backend/Ledger.Domain/Accounts/Account.cs
@@ -38,7 +38,21 @@ public sealed class Account
 
     public LedgerEntry AddEntry(EntryType type, decimal amount, string? description)
     {
-        var entry = LedgerEntry.Create(Id, type, amount, description);
+        // validate amount using Money
+        var money = Money.From(amount);
+
+        // enforce "no overdraft" rule
+        if(type == EntryType.Debit)
+        {
+            var currentBalance = GetBalance(); // sum of existing entries
+
+            if(currentBalance < money.Value)
+            {
+                throw new DomainException("Insufficient funds: debit amount exceeds current balance.");
+            }
+        }
+
+        var entry = LedgerEntry.Create(Id, type, money.Value, description);
         _entries.Add(entry);
         return entry;
     }


### PR DESCRIPTION
## Summary

This PR enforces a `no overdraft` business rule so debit transactions cannot exceed the current account balance.

## What Changed

- Added domain validation in Account.AddEntry():
  - Credits are always allowed
  - Debits are rejected if currentBalance < debitAmount
- Throws DomainException for insufficient funds to ensure consistent API error responses

## Result

- Prevents negative balances
- Keeps business rules centralized in the Domain layer (encapsulation)