### PR TITLE
Add Total Credits/Debits to Ledger Response

### DIFF
--- a/backend/Ledger.Application/Ledger/Dtos/AccountLedgerDto.cs
+++ b/backend/Ledger.Application/Ledger/Dtos/AccountLedgerDto.cs
@@ -3,5 +3,7 @@ namespace Ledger.Application.Ledger.Dtos;
 public sealed record AccountLedgerDto(
     Guid AccountId,
     decimal Balance,
+    decimal TotalCredits,
+    decimal TotalDebits,
     List<LedgerEntryDto> Entries
 );

--- a/backend/Ledger.Application/Ledger/LedgerService.cs
+++ b/backend/Ledger.Application/Ledger/LedgerService.cs
@@ -57,11 +57,18 @@ public sealed class LedgerService : ILedgerService
 
         var entries = await _entries.GetByAccountIdAsync(account.Id, ct);
 
+        var totalCredits = entries.Where(e => e.Type == EntryType.Credit).Sum(e => e.Amount.Value);
+
+        var totalDebits = entries.Where(e => e.Type == EntryType.Debit).Sum(e => e.Amount.Value);
+
         var balance = entries.Sum(e => e.SignedAmount());
 
         return new AccountLedgerDto(
             account.Id.Value,
             balance,
+            totalCredits,
+            totalDebits,
+
             entries.Select(e => new LedgerEntryDto(
                 e.Id,
                 e.AccountId.Value,

--- a/frontend/src/features/ledger/LedgerView.jsx
+++ b/frontend/src/features/ledger/LedgerView.jsx
@@ -126,12 +126,8 @@ export default function LedgerView({ accountId, accountName }) {
 
   const balance = data?.balance ?? 0;
   const entries = data?.entries ?? [];
-  const totalCredits = entries
-    .filter((e) => e.type === 2)
-    .reduce((sum, e) => sum + e.amount, 0);
-  const totalDebits = entries
-    .filter((e) => e.type === 1)
-    .reduce((sum, e) => sum + e.amount, 0);
+  const totalCredits = data?.totalCredits ?? 0;
+  const totalDebits = data?.totalDebits ?? 0;
 
   return (
     <div className="space-y-6">
@@ -200,9 +196,6 @@ export default function LedgerView({ accountId, accountName }) {
         <div className="border-b border-slate-100 p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <div className="rounded-lg bg-blue-50 p-2">
-                <PlusCircle className="h-5 w-5 text-blue-600" />
-              </div>
               <h2 className="font-semibold text-slate-900">Add New Entry</h2>
             </div>
             <button


### PR DESCRIPTION
## Summary

This PR enhances the ledger response to include aggregated totals for credits and debits per account.

## What Changed

- Added `TotalCredits` and `TotalDebits` to `AccountLedgerDto`
- Updated `LedgerService.GetAccountLedgerAsync` to compute and return totals alongside balance and entries

## Result

- Frontend can display balance + total credits + total debits without extra API calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Total credits and debits are now calculated server-side and provided directly in account ledger responses, optimizing data efficiency.

* **Style**
  * Simplified the ledger entry header by removing a decorative icon element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->